### PR TITLE
Fix 'expression is not assignable'

### DIFF
--- a/rbtree.c
+++ b/rbtree.c
@@ -15,13 +15,6 @@
 #define RETURN_ENUMERATOR(obj, argc, argv) ((void)0)
 #endif
 
-#ifndef RHASH_TBL
-#define RHASH_TBL(h) RHASH(h)->tbl
-#endif
-#ifndef RHASH_IFNONE
-#define RHASH_IFNONE(h) RHASH(h)->ifnone
-#endif
-
 VALUE RBTree;
 VALUE MultiRBTree;
 
@@ -145,7 +138,7 @@ rbtree_alloc(VALUE klass)
                        (void*)Qnil);
     if (klass == MultiRBTree)
         dict_allow_dupes(dict);
-    
+
     DICT(rbtree) = dict;
     IFNONE(rbtree) = Qnil;
     return rbtree;
@@ -174,27 +167,27 @@ rbtree_s_create(int argc, VALUE* argv, VALUE klass)
 {
     long i;
     VALUE rbtree;
-    
+
     if (argc == 1) {
         VALUE tmp;
-        
+
         if (klass == RBTree && CLASS_OF(argv[0]) == MultiRBTree) {
             rb_raise(rb_eTypeError, "can't convert MultiRBTree to RBTree");
         }
-        
+
         if (rb_obj_is_kind_of(argv[0], klass)) {
             rbtree = rbtree_alloc(klass);
             rbtree_update(rbtree, argv[0]);
             return rbtree;
         }
-        
+
         tmp = rb_check_convert_type(argv[0], T_HASH, "Hash", "to_hash");
         if (!NIL_P(tmp)) {
             rbtree = rbtree_alloc(klass);
             st_foreach(RHASH_TBL(tmp), hash_to_rbtree_i, rbtree);
             return rbtree;
         }
-        
+
         tmp = rb_check_array_type(argv[0]);
         if (!NIL_P(tmp)) {
             rbtree = rbtree_alloc(klass);
@@ -217,7 +210,7 @@ rbtree_s_create(int argc, VALUE* argv, VALUE klass)
             return rbtree;
         }
     }
-    
+
     if (argc % 2 != 0)
         rb_raise(rb_eArgError, "odd number of arguments for RBTree");
 
@@ -482,7 +475,7 @@ rbtree_each_body(rbtree_each_arg_t* arg)
     dnode_t* node;
     dnode_t* first_node;
     dnode_t* (*next_func)(dict_t*, dnode_t*);
-    
+
     if (arg->reverse) {
         first_node = dict_last(dict);
         next_func = dict_prev;
@@ -490,12 +483,12 @@ rbtree_each_body(rbtree_each_arg_t* arg)
         first_node = dict_first(dict);
         next_func = dict_next;
     }
-    
+
     ITER_LEV(self)++;
     for (node = first_node;
          node != NULL;
          node = next_func(dict, node)) {
-        
+
         if (arg->func(node, arg->arg) == EACH_STOP)
             break;
     }
@@ -662,9 +655,9 @@ rbtree_initialize_copy(VALUE self, VALUE other)
                  rb_class2name(CLASS_OF(other)),
                  rb_class2name(CLASS_OF(self)));
     }
-    
+
     copy_dict(other, self, COMPARE(other), CONTEXT(other));
-    
+
     IFNONE(self) = IFNONE(other);
     if (FL_TEST(other, RBTREE_PROC_DEFAULT))
         FL_SET(self, RBTREE_PROC_DEFAULT);
@@ -681,7 +674,7 @@ rbtree_values_at(int argc, VALUE* argv, VALUE self)
 {
     long i;
     VALUE ary = rb_ary_new();
-    
+
     for (i = 0; i < argc; i++)
         rb_ary_push(ary, rbtree_aref(self, argv[i]));
     return ary;
@@ -702,7 +695,7 @@ VALUE
 rbtree_select(VALUE self)
 {
     VALUE ary;
-    
+
     RETURN_ENUMERATOR(self, 0, NULL);
     ary = rb_ary_new();
     rbtree_for_each(self, select_i, (void*)ary);
@@ -827,7 +820,7 @@ VALUE
 rbtree_delete_if(VALUE self)
 {
     rbtree_delete_if_arg_t arg;
-    
+
     RETURN_ENUMERATOR(self, 0, NULL);
     rbtree_modify(self);
     arg.self = self;
@@ -843,7 +836,7 @@ VALUE
 rbtree_reject_bang(VALUE self)
 {
     dictcount_t count;
-    
+
     RETURN_ENUMERATOR(self, 0, NULL);
     count = dict_count(DICT(self));
     rbtree_delete_if(self);
@@ -958,7 +951,7 @@ rbtree_update(VALUE self, VALUE other)
                  rb_class2name(CLASS_OF(other)),
                  rb_class2name(CLASS_OF(self)));
     }
-    
+
     if (rb_block_given_p())
         rbtree_for_each(other, update_block_i, (void*)self);
     else
@@ -1080,10 +1073,9 @@ rbtree_to_hash(VALUE self)
     if (CLASS_OF(self) == MultiRBTree) {
         rb_raise(rb_eTypeError, "can't convert MultiRBTree to Hash");
     }
-    
+
     hash = rb_hash_new();
     rbtree_for_each(self, to_hash_i, (void*)hash);
-    RHASH_IFNONE(hash) = IFNONE(self);
     if (FL_TEST(self, RBTREE_PROC_DEFAULT))
         FL_SET(hash, HASH_PROC_DEFAULT);
     OBJ_INFECT(hash, self);
@@ -1167,7 +1159,7 @@ static VALUE
 inspect_rbtree(VALUE self, VALUE ret)
 {
     VALUE str;
-    
+
     rb_str_cat2(ret, "{");
     RSTRING_PTR(ret)[0] = '-';
     rbtree_for_each(self, inspect_i, (void*)ret);
@@ -1178,7 +1170,7 @@ inspect_rbtree(VALUE self, VALUE ret)
     rb_str_cat2(ret, ", default=");
     rb_str_append(ret, str);
     OBJ_INFECT(ret, str);
-    
+
     str = rb_inspect((VALUE)CONTEXT(self));
     rb_str_cat2(ret, ", cmp_proc=");
     rb_str_append(ret, str);
@@ -1302,14 +1294,14 @@ rbtree_bound(int argc, VALUE* argv, VALUE self)
     dnode_t* lower_node;
     dnode_t* upper_node;
     VALUE ret;
-    
+
     if (argc == 0 || argc > 2)
         rbtree_argc_error();
-    
+
     lower_node = dict_lower_bound(dict, TO_KEY(argv[0]));
     upper_node = dict_upper_bound(dict, TO_KEY(argv[argc - 1]));
     ret = rb_block_given_p() ? self : rb_ary_new();
-    
+
     if (lower_node == NULL || upper_node == NULL ||
         COMPARE(self)(dnode_getkey(lower_node),
                       dnode_getkey(upper_node),
@@ -1339,7 +1331,7 @@ rbtree_first_last(VALUE self, const int first)
         }
         return IFNONE(self);
     }
-    
+
     if (first)
         node = dict_first(dict);
     else
@@ -1391,7 +1383,7 @@ rbtree_readjust(int argc, VALUE* argv, VALUE self)
 {
     dict_comp_t cmp = NULL;
     void* context = NULL;
-    
+
     rbtree_modify(self);
 
     if (argc == 0) {
@@ -1525,12 +1517,12 @@ rbtree_dump(VALUE self, VALUE limit)
 {
     VALUE ary;
     VALUE ret;
-    
+
     if (FL_TEST(self, RBTREE_PROC_DEFAULT))
         rb_raise(rb_eTypeError, "cannot dump rbtree with default proc");
     if ((VALUE)CONTEXT(self) != Qnil)
         rb_raise(rb_eTypeError, "cannot dump rbtree with compare proc");
-    
+
     ary = rb_ary_new2(dict_count(DICT(self)) * 2 + 1);
     rbtree_for_each(self, to_flatten_ary_i, (void*)ary);
     rb_ary_push(ary, IFNONE(self));
@@ -1552,11 +1544,11 @@ rbtree_s_load(VALUE klass, VALUE str)
     VALUE* ptr = RARRAY_PTR(ary);
     long len = RARRAY_LEN(ary) - 1;
     long i;
-    
+
     for (i = 0; i < len; i += 2)
         rbtree_aset(rbtree, ptr[i], ptr[i + 1]);
     IFNONE(rbtree) = ptr[len];
-    
+
     rb_ary_clear(ary);
     rb_gc_force_recycle(ary);
     return rbtree;
@@ -1576,40 +1568,40 @@ rbtree_s_load(VALUE klass, VALUE str)
  * case. On the other hand the complexity of Hash is O(1). Because
  * Hash is unordered the data structure is more effective than
  * Red-Black Tree as an associative collection.
- * 
+ *
  * The elements of RBTree are sorted with natural ordering (by <=>
  * method) of its keys or by a comparator(Proc) set by readjust
  * method. It means all keys in RBTree should be comparable with each
  * other. Or a comparator that takes two arguments of a key should return
  * negative, 0, or positive depending on the first argument is less than,
  * equal to, or greater than the second one.
- * 
+ *
  * The interface of RBTree is the almost same as Hash and there are a
  * few methods to take advantage of the ordering:
- * 
+ *
  * * lower_bound, upper_bound, bound
  * * first, last
  * * shift, pop
  * * reverse_each
- * 
+ *
  * Note: while iterating RBTree (e.g. in a block of each method), it is
  * not modifiable, or TypeError is thrown.
- * 
+ *
  * RBTree supoorts pretty printing using pp.
- * 
+ *
  * This library contains two classes. One is RBTree and the other is
  * MultiRBTree that is a parent class of RBTree. RBTree does not allow
  * duplications of keys but MultiRBTree does.
  *
  *   require "rbtree"
- *   
+ *
  *   rbtree = RBTree["c", 10, "a", 20]
  *   rbtree["b"] = 30
  *   p rbtree["b"]              # => 30
  *   rbtree.each do |k, v|
  *     p [k, v]
  *   end                        # => ["a", 20] ["b", 30] ["c", 10]
- *   
+ *
  *   mrbtree = MultiRBTree["c", 10, "a", 20, "e", 30, "a", 40]
  *   p mrbtree.lower_bound("b") # => ["c", 10]
  *   mrbtree.bound("a", "d") do |k, v|
@@ -1690,7 +1682,7 @@ void Init_rbtree()
 
     rb_define_method(MultiRBTree, "_dump", rbtree_dump, 1);
     rb_define_singleton_method(MultiRBTree, "_load", rbtree_s_load, 1);
-    
+
     id_bound = rb_intern("bound");
     id_cmp = rb_intern("<=>");
     id_call = rb_intern("call");

--- a/test.rb
+++ b/test.rb
@@ -5,7 +5,7 @@ class RBTreeTest < Test::Unit::TestCase
   def setup
     @rbtree = RBTree[*%w(b B d D a A c C)]
   end
-  
+
   def test_new
     assert_nothing_raised {
       RBTree.new
@@ -15,86 +15,86 @@ class RBTreeTest < Test::Unit::TestCase
     assert_raises(ArgumentError) { RBTree.new("a") {} }
     assert_raises(ArgumentError) { RBTree.new("a", "a") }
   end
-  
+
   def test_aref
     assert_equal("A", @rbtree["a"])
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     assert_equal(nil, @rbtree["e"])
     @rbtree.default = "E"
     assert_equal("E", @rbtree["e"])
   end
-  
+
   def test_size
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_create
     rbtree = RBTree[]
     assert_equal(0, rbtree.size)
-    
+
     rbtree = RBTree[@rbtree]
     assert_equal(4, rbtree.size)
     assert_equal("A", @rbtree["a"])
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     rbtree = RBTree[RBTree.new("e")]
     assert_equal(nil, rbtree.default)
     rbtree = RBTree[RBTree.new { "e" }]
     assert_equal(nil, rbtree.default_proc)
     @rbtree.readjust {|a,b| b <=> a }
     assert_equal(nil, RBTree[@rbtree].cmp_proc)
-    
+
     assert_raises(ArgumentError) { RBTree["e"] }
-    
+
     rbtree = RBTree[Hash[*%w(b B d D a A c C)]]
     assert_equal(4, rbtree.size)
     assert_equal("A", rbtree["a"])
     assert_equal("B", rbtree["b"])
     assert_equal("C", rbtree["c"])
     assert_equal("D", rbtree["d"])
-    
+
     rbtree = RBTree[[%w(a A), %w(b B), %w(c C), %w(d D)]];
     assert_equal(4, rbtree.size)
     assert_equal("A", rbtree["a"])
     assert_equal("B", rbtree["b"])
     assert_equal("C", rbtree["c"])
     assert_equal("D", rbtree["d"])
-    
+
     rbtree = RBTree[[["a"]]]
     assert_equal(1, rbtree.size)
     assert_equal(nil, rbtree["a"])
   end
-  
+
   def test_clear
     @rbtree.clear
     assert_equal(0, @rbtree.size)
   end
-  
+
   def test_aset
     @rbtree["e"] = "E"
     assert_equal(5, @rbtree.size)
     assert_equal("E", @rbtree["e"])
-    
+
     @rbtree["c"] = "E"
     assert_equal(5, @rbtree.size)
     assert_equal("E", @rbtree["c"])
-    
+
     assert_raises(ArgumentError) { @rbtree[100] = 100 }
     assert_equal(5, @rbtree.size)
-    
-    
+
+
     key = "f"
     @rbtree[key] = "F"
     cloned_key = @rbtree.last[0]
     assert_equal("f", cloned_key)
     assert_not_same(key, cloned_key)
     assert_equal(true, cloned_key.frozen?)
-    
+
     @rbtree["f"] = "F"
     assert_same(cloned_key, @rbtree.last[0])
 
@@ -104,7 +104,7 @@ class RBTreeTest < Test::Unit::TestCase
     assert_same(key, rbtree.first[0])
     assert_equal(false, key.frozen?)
   end
-  
+
   def test_clone
     clone = @rbtree.clone
     assert_equal(4, @rbtree.size)
@@ -112,53 +112,53 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     rbtree = RBTree.new("e")
     clone = rbtree.clone
     assert_equal("e", clone.default)
-    
+
     rbtree = RBTree.new { "e" }
     clone = rbtree.clone
     assert_equal("e", clone.default(nil))
-    
+
     rbtree = RBTree.new
     rbtree.readjust {|a, b| a <=> b }
     clone = rbtree.clone
     assert_equal(rbtree.cmp_proc, clone.cmp_proc)
   end
-  
+
   def test_default
     assert_equal(nil, @rbtree.default)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.default)
     assert_equal("e", rbtree.default("f"))
     assert_raises(ArgumentError) { rbtree.default("e", "f") }
-    
+
     rbtree = RBTree.new {|tree, key| @rbtree[key || "c"] }
     assert_equal("C", rbtree.default(nil))
     assert_equal("B", rbtree.default("b"))
   end
-  
+
   def test_set_default
     rbtree = RBTree.new { "e" }
     rbtree.default = "f"
     assert_equal("f", rbtree.default)
   end
-  
+
   def test_default_proc
     rbtree = RBTree.new("e")
     assert_equal(nil, rbtree.default_proc)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.default_proc.call)
   end
-  
+
   def test_equal
     assert_equal(RBTree.new, RBTree.new)
     assert_equal(@rbtree, @rbtree)
     assert_not_equal(@rbtree, RBTree.new)
-    
+
     rbtree = RBTree[*%w(b B d D a A c C)]
     assert_equal(@rbtree, rbtree)
     rbtree["d"] = "A"
@@ -168,17 +168,17 @@ class RBTreeTest < Test::Unit::TestCase
     assert_not_equal(@rbtree, rbtree)
     @rbtree["e"] = "E"
     assert_equal(@rbtree, rbtree)
-    
+
     rbtree.default = "e"
     assert_equal(@rbtree, rbtree)
     @rbtree.default = "f"
     assert_equal(@rbtree, rbtree)
-    
+
     a = RBTree.new("e")
     b = RBTree.new { "f" }
     assert_equal(a, b)
     assert_equal(b, b.clone)
-    
+
     a = RBTree.new
     b = RBTree.new
     a.readjust {|x, y| x <=> y }
@@ -186,15 +186,15 @@ class RBTreeTest < Test::Unit::TestCase
     b.readjust(a.cmp_proc)
     assert_equal(a, b)
   end
-  
+
   def test_fetch
     assert_equal("A", @rbtree.fetch("a"))
     assert_equal("B", @rbtree.fetch("b"))
     assert_equal("C", @rbtree.fetch("c"))
     assert_equal("D", @rbtree.fetch("d"))
-    
+
     assert_raises(IndexError) { @rbtree.fetch("e") }
-    
+
     assert_equal("E", @rbtree.fetch("e", "E"))
     assert_equal("E", @rbtree.fetch("e") { "E" })
     class << (stderr = "")
@@ -207,7 +207,7 @@ class RBTreeTest < Test::Unit::TestCase
       $stderr, stderr, $VERBOSE, verbose = stderr, $stderr, false, $VERBOSE
     end
     assert_match(/warning: block supersedes default value argument/, stderr)
-    
+
     assert_raises(ArgumentError) { @rbtree.fetch }
     assert_raises(ArgumentError) { @rbtree.fetch("e", "E", "E") }
   end
@@ -222,17 +222,17 @@ class RBTreeTest < Test::Unit::TestCase
     @rbtree.clear
     assert_equal(true, @rbtree.empty?)
   end
-  
+
   def test_each
     ret = []
     @rbtree.each {|key, val| ret << key << val }
     assert_equal(%w(a A b B c C d D), ret)
-    
+
     assert_raises(TypeError) {
       @rbtree.each { @rbtree["e"] = "E" }
     }
     assert_equal(4, @rbtree.size)
-    
+
     @rbtree.each {
       @rbtree.each {}
       assert_raises(TypeError) {
@@ -241,13 +241,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each
       assert_equal(%w(a A b B c C d D), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_pair
     ret = []
     @rbtree.each_pair {|key, val| ret << key << val }
@@ -266,13 +266,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_pair
       assert_equal(%w(a A b B c C d D), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_key
     ret = []
     @rbtree.each_key {|key| ret.push(key) }
@@ -291,13 +291,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_key
       assert_equal(%w(a b c d), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_value
     ret = []
     @rbtree.each_value {|val| ret.push(val) }
@@ -316,7 +316,7 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_value
       assert_equal(%w(A B C D), enumerator.map.flatten)
@@ -328,52 +328,52 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal(3, @rbtree.size)
     assert_equal(["a", "A"], ret)
     assert_equal(nil, @rbtree["a"])
-    
+
     3.times { @rbtree.shift }
     assert_equal(0, @rbtree.size)
     assert_equal(nil, @rbtree.shift)
     @rbtree.default = "e"
     assert_equal("e", @rbtree.shift)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.shift)
   end
-  
+
   def test_pop
     ret = @rbtree.pop
     assert_equal(3, @rbtree.size)
     assert_equal(["d", "D"], ret)
     assert_equal(nil, @rbtree["d"])
-    
+
     3.times { @rbtree.pop }
     assert_equal(0, @rbtree.size)
     assert_equal(nil, @rbtree.pop)
     @rbtree.default = "e"
     assert_equal("e", @rbtree.pop)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.pop)
   end
-  
+
   def test_delete
     ret = @rbtree.delete("c")
     assert_equal("C", ret)
     assert_equal(3, @rbtree.size)
     assert_equal(nil, @rbtree["c"])
-    
+
     assert_equal(nil, @rbtree.delete("e"))
     assert_equal("E", @rbtree.delete("e") { "E" })
   end
-  
+
   def test_delete_if
     @rbtree.delete_if {|key, val| val == "A" || val == "B" }
     assert_equal(RBTree[*%w(c C d D)], @rbtree)
-    
+
     assert_raises(ArgumentError) {
       @rbtree.delete_if {|key, val| key == "c" or raise ArgumentError }
     }
     assert_equal(2, @rbtree.size)
-    
+
     assert_raises(TypeError) {
       @rbtree.delete_if { @rbtree["e"] = "E" }
     }
@@ -389,7 +389,7 @@ class RBTreeTest < Test::Unit::TestCase
       true
     }
     assert_equal(0, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       rbtree = RBTree[*%w(b B d D a A c C)]
       enumerator = rbtree.delete_if
@@ -401,38 +401,38 @@ class RBTreeTest < Test::Unit::TestCase
     ret = @rbtree.reject! { false }
     assert_equal(nil, ret)
     assert_equal(4, @rbtree.size)
-    
+
     ret = @rbtree.reject! {|key, val| val == "A" || val == "B" }
     assert_same(@rbtree, ret)
     assert_equal(RBTree[*%w(c C d D)], ret)
-    
+
     if defined?(Enumerable::Enumerator)
       rbtree = RBTree[*%w(b B d D a A c C)]
       enumerator = rbtree.reject!
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B" })
     end
   end
-  
+
   def test_reject
     ret = @rbtree.reject { false }
     assert_equal(nil, ret)
     assert_equal(4, @rbtree.size)
-    
+
     ret = @rbtree.reject {|key, val| val == "A" || val == "B" }
     assert_equal(RBTree[*%w(c C d D)], ret)
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.reject
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B" })
     end
   end
-  
+
   def test_select
     ret = @rbtree.select {|key, val| val == "A" || val == "B" }
     assert_equal(%w(a A b B), ret.flatten)
     assert_raises(ArgumentError) { @rbtree.select("c") }
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.select
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B"})
@@ -443,40 +443,40 @@ class RBTreeTest < Test::Unit::TestCase
     ret = @rbtree.values_at("d", "a", "e")
     assert_equal(["D", "A", nil], ret)
   end
-  
+
   def test_invert
     assert_equal(RBTree[*%w(A a B b C c D d)], @rbtree.invert)
   end
-  
+
   def test_update
     rbtree = RBTree.new
     rbtree["e"] = "E"
     @rbtree.update(rbtree)
     assert_equal(RBTree[*%w(a A b B c C d D e E)], @rbtree)
-    
+
     @rbtree.clear
     @rbtree["d"] = "A"
     rbtree.clear
     rbtree["d"] = "B"
-    
+
     @rbtree.update(rbtree) {|key, val1, val2|
       val1 + val2 if key == "d"
     }
     assert_equal(RBTree[*%w(d AB)], @rbtree)
-    
+
     assert_raises(TypeError) { @rbtree.update("e") }
   end
-  
+
   def test_merge
     rbtree = RBTree.new
     rbtree["e"] = "E"
-    
+
     ret = @rbtree.merge(rbtree)
     assert_equal(RBTree[*%w(a A b B c C d D e E)], ret)
-    
+
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_has_key
     assert_equal(true,  @rbtree.has_key?("a"))
     assert_equal(true,  @rbtree.has_key?("b"))
@@ -484,7 +484,7 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal(true,  @rbtree.has_key?("d"))
     assert_equal(false, @rbtree.has_key?("e"))
   end
-  
+
   def test_has_value
     assert_equal(true,  @rbtree.has_value?("A"))
     assert_equal(true,  @rbtree.has_value?("B"))
@@ -513,38 +513,29 @@ class RBTreeTest < Test::Unit::TestCase
       assert_equal(val, @rbtree.to_s)
     end
   end
-  
+
   def test_to_hash
     @rbtree.default = "e"
     hash = @rbtree.to_hash
     assert_equal(@rbtree.to_a.flatten, hash.to_a.flatten)
-    assert_equal("e", hash.default)
-
-    rbtree = RBTree.new { "e" }
-    hash = rbtree.to_hash
-    if (hash.respond_to?(:default_proc))
-      assert_equal(rbtree.default_proc, hash.default_proc)
-    else
-      assert_equal(rbtree.default_proc, hash.default)
-    end
   end
 
   def test_to_rbtree
     assert_same(@rbtree, @rbtree.to_rbtree)
   end
-  
+
   def test_inspect
     @rbtree.default = "e"
     @rbtree.readjust {|a, b| a <=> b}
     re = /#<RBTree: (\{.*\}), default=(.*), cmp_proc=(.*)>/
-    
+
     assert_match(re, @rbtree.inspect)
     match = re.match(@rbtree.inspect)
     tree, default, cmp_proc = match.to_a[1..-1]
     assert_equal(%({"a"=>"A", "b"=>"B", "c"=>"C", "d"=>"D"}), tree)
     assert_equal(%("e"), default)
     assert_match(/#<Proc:\w+(@#{__FILE__}:\d+)?>/o, cmp_proc)
-    
+
     rbtree = RBTree.new
     assert_match(re, rbtree.inspect)
     match = re.match(rbtree.inspect)
@@ -552,28 +543,28 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal("{}", tree)
     assert_equal("nil", default)
     assert_equal("nil", cmp_proc)
-    
+
     rbtree = RBTree.new
     rbtree["e"] = rbtree
     assert_match(re, rbtree.inspect)
     match = re.match(rbtree.inspect)
     assert_equal(%({"e"=>#<RBTree: ...>}), match[1])
   end
-  
+
   def test_lower_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(["c", "C"], rbtree.lower_bound("c"))
     assert_equal(["c", "C"], rbtree.lower_bound("b"))
     assert_equal(nil, rbtree.lower_bound("f"))
   end
-  
+
   def test_upper_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(["c", "C"], rbtree.upper_bound("c"))
     assert_equal(["c", "C"], rbtree.upper_bound("d"))
     assert_equal(nil, rbtree.upper_bound("Z"))
   end
-  
+
   def test_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(%w(a A c C), rbtree.bound("a", "c").flatten)
@@ -585,21 +576,21 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal([], rbtree.bound("f", "g"))
     assert_equal([], rbtree.bound("f", "Z"))
   end
-  
+
   def test_bound_block
     ret = []
     @rbtree.bound("b", "c") {|key, val|
       ret.push(key)
     }
     assert_equal(%w(b c), ret)
-    
+
     assert_raises(TypeError) {
       @rbtree.bound("a", "d") {
         @rbtree["e"] = "E"
       }
     }
     assert_equal(4, @rbtree.size)
-    
+
     @rbtree.bound("b", "c") {
       @rbtree.bound("b", "c") {}
       assert_raises(TypeError) {
@@ -609,10 +600,10 @@ class RBTreeTest < Test::Unit::TestCase
     }
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_first
     assert_equal(["a", "A"], @rbtree.first)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.first)
 
@@ -622,7 +613,7 @@ class RBTreeTest < Test::Unit::TestCase
 
   def test_last
     assert_equal(["d", "D"], @rbtree.last)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.last)
 
@@ -632,26 +623,26 @@ class RBTreeTest < Test::Unit::TestCase
 
   def test_readjust
     assert_equal(nil, @rbtree.cmp_proc)
-    
+
     @rbtree.readjust {|a, b| b <=> a }
     assert_equal(%w(d c b a), @rbtree.keys)
     assert_not_equal(nil, @rbtree.cmp_proc)
-    
+
     proc = Proc.new {|a,b| a.to_s <=> b.to_s }
     @rbtree.readjust(proc)
     assert_equal(%w(a b c d), @rbtree.keys)
     assert_equal(proc, @rbtree.cmp_proc)
-    
+
     @rbtree[0] = nil
     assert_raises(ArgumentError) { @rbtree.readjust(nil) }
     assert_equal(5, @rbtree.size)
     assert_equal(proc, @rbtree.cmp_proc)
-    
+
     @rbtree.delete(0)
     @rbtree.readjust(nil)
     assert_raises(ArgumentError) { @rbtree[0] = nil }
-    
-    
+
+
     rbtree = RBTree.new
     key = ["a"]
     rbtree[key] = nil
@@ -669,57 +660,57 @@ class RBTreeTest < Test::Unit::TestCase
     }
     assert_raises(ArgumentError) { @rbtree.readjust(proc, proc) }
   end
-  
+
   def test_replace
     rbtree = RBTree.new { "e" }
     rbtree.readjust {|a, b| a <=> b}
     rbtree["a"] = "A"
     rbtree["e"] = "E"
-    
+
     @rbtree.replace(rbtree)
     assert_equal(%w(a A e E), @rbtree.to_a.flatten)
-    assert_equal(rbtree.default, @rbtree.default)    
+    assert_equal(rbtree.default, @rbtree.default)
     assert_equal(rbtree.cmp_proc, @rbtree.cmp_proc)
 
     assert_raises(TypeError) { @rbtree.replace("e") }
   end
-  
+
   def test_reverse_each
     ret = []
     @rbtree.reverse_each { |key, val| ret.push([key, val]) }
     assert_equal(%w(d D c C b B a A), ret.flatten)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.reverse_each
       assert_equal(%w(d D c C b B a A), enumerator.map.flatten)
     end
   end
-  
+
   def test_marshal
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
-    
+
     @rbtree.default = "e"
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
-    
+
     assert_raises(TypeError) {
       Marshal.dump(RBTree.new { "e" })
     }
-    
+
     assert_raises(TypeError) {
       @rbtree.readjust {|a, b| a <=> b}
       Marshal.dump(@rbtree)
     }
   end
-  
+
   begin
     require "pp"
-    
+
     def test_pp
       assert_equal(%(#<RBTree: {}, default=nil, cmp_proc=nil>\n),
                    PP.pp(RBTree[], ""))
       assert_equal(%(#<RBTree: {"a"=>"A", "b"=>"B"}, default=nil, cmp_proc=nil>\n),
                    PP.pp(RBTree[*%w(a A b B)], ""))
-      
+
       rbtree = RBTree[*("a".."z").to_a]
       rbtree.default = "a"
       rbtree.readjust {|a, b| a <=> b }
@@ -764,7 +755,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
 
   def test_create
     assert_equal(%w(a A b B b C b D c C), @rbtree.to_a.flatten)
-    
+
     assert_equal(MultiRBTree[*%w(a A)], MultiRBTree[RBTree[*%w(a A)]])
     assert_raises(TypeError) {
       RBTree[MultiRBTree[*%w(a A)]]
@@ -785,7 +776,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     @rbtree.clear
     assert_equal(true, @rbtree.empty?)
   end
-  
+
   def test_to_a
     assert_equal([%w(a A), %w(b B), %w(b C), %w(b D), %w(c C)],
                  @rbtree.to_a)
@@ -800,7 +791,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
       assert_equal(val, @rbtree.to_s)
     end
   end
-  
+
   def test_to_hash
     assert_raises(TypeError) {
       @rbtree.to_hash
@@ -826,7 +817,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     assert_equal(true, RBTree[*%w(a A)] == MultiRBTree[*%w(a A)])
     assert_equal(true, MultiRBTree[*%w(a A)] == RBTree[*%w(a A)])
   end
-  
+
   def test_replace
     assert_equal(RBTree[*%w(a A)],
                  MultiRBTree[*%w(a A)].replace(RBTree[*%w(a A)]))
@@ -846,7 +837,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
   def test_clone
     assert_equal(@rbtree, @rbtree.clone)
   end
-  
+
   def test_each
     ret = []
     @rbtree.each {|k, v|
@@ -883,7 +874,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     @rbtree.readjust {|a, b| b <=> a }
     assert_equal(%w(c C b B b C b D a A), @rbtree.to_a.flatten)
   end
-  
+
   def test_marshal
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
   end
@@ -899,7 +890,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
   def test_bound
     assert_equal(%w(b B b C b D), @rbtree.bound("b").flatten)
   end
-  
+
   def test_first
     assert_equal(%w(a A), @rbtree.first)
   end


### PR DESCRIPTION
When trying to compile the project I hit the following issue:

```
rbtree.c:1086:24: error: expression is not assignable
    RHASH_IFNONE(hash) = IFNONE(self);
```

The problem is that this API is no longer public. It was made private in:
https://bugs.ruby-lang.org/issues/9889

With this change we no longer support smooth transition between RBTree and Hash,
which preserves default value. I'm not 100% sure that dropping support is the
right way but there's only much I can do. My Ruby C API knowledge is not very
deep.

This can potentially break someone's code but it doesn't seem to be too
critical.