### PR TITLE
The taint mechanism was deprecated in Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - checkout
       - <<: *unit
+  "ruby-2.7":
+    docker:
+      - image: circleci/ruby:2.7.0
+    steps:
+      - checkout
+      - <<: *unit
 
 workflows:
   version: 2
@@ -53,3 +59,4 @@ workflows:
       - "ruby-2.4"
       - "ruby-2.5"
       - "ruby-2.6"
+      - "ruby-2.7"

--- a/rbtree.c
+++ b/rbtree.c
@@ -15,6 +15,10 @@
 #define RETURN_ENUMERATOR(obj, argc, argv) ((void)0)
 #endif
 
+#ifndef RHASH_SET_IFNONE
+#define RHASH_SET_IFNONE(h, ifnone) (RHASH_IFNONE(h) = ifnone)
+#endif
+
 #if !defined(RUBY_API_VERSION_CODE) || (RUBY_API_VERSION_CODE < 20700)
 #define HAVE_TAINT
 #endif
@@ -1084,6 +1088,7 @@ rbtree_to_hash(VALUE self)
 
     hash = rb_hash_new();
     rbtree_for_each(self, to_hash_i, (void*)hash);
+    RHASH_SET_IFNONE(hash, IFNONE(self));
     if (FL_TEST(self, RBTREE_PROC_DEFAULT))
         FL_SET(hash, HASH_PROC_DEFAULT);
 #ifdef HAVE_TAINT

--- a/rbtree.c
+++ b/rbtree.c
@@ -15,6 +15,10 @@
 #define RETURN_ENUMERATOR(obj, argc, argv) ((void)0)
 #endif
 
+#if !defined(RUBY_API_VERSION_CODE) || (RUBY_API_VERSION_CODE < 20700)
+#define HAVE_TAINT
+#endif
+
 VALUE RBTree;
 VALUE MultiRBTree;
 
@@ -121,8 +125,10 @@ rbtree_modify(VALUE self)
         rb_raise(rb_eTypeError, "can't modify rbtree in iteration");
     if (OBJ_FROZEN(self))
         rb_error_frozen("rbtree");
+#ifdef HAVE_TAINT
     if (!OBJ_TAINTED(self) && rb_safe_level() >= 4)
         rb_raise(rb_eSecurityError, "Insecure: can't modify rbtree");
+#endif
 }
 
 static VALUE
@@ -1052,7 +1058,9 @@ rbtree_to_a(VALUE self)
 {
     VALUE ary = rb_ary_new();
     rbtree_for_each(self, to_a_i, (void*)ary);
+#ifdef HAVE_TAINT
     OBJ_INFECT(ary, self);
+#endif
     return ary;
 }
 
@@ -1078,7 +1086,9 @@ rbtree_to_hash(VALUE self)
     rbtree_for_each(self, to_hash_i, (void*)hash);
     if (FL_TEST(self, RBTREE_PROC_DEFAULT))
         FL_SET(hash, HASH_PROC_DEFAULT);
+#ifdef HAVE_TAINT
     OBJ_INFECT(hash, self);
+#endif
     return hash;
 }
 
@@ -1144,13 +1154,17 @@ inspect_i(dnode_t* node, void* ret_)
 
     str = rb_inspect(GET_KEY(node));
     rb_str_append(ret, str);
+#ifdef HAVE_TAINT
     OBJ_INFECT(ret, str);
+#endif
 
     rb_str_cat2(ret, "=>");
 
     str = rb_inspect(GET_VAL(node));
     rb_str_append(ret, str);
+#ifdef HAVE_TAINT
     OBJ_INFECT(ret, str);
+#endif
 
     return EACH_NEXT;
 }
@@ -1169,15 +1183,21 @@ inspect_rbtree(VALUE self, VALUE ret)
     str = rb_inspect(IFNONE(self));
     rb_str_cat2(ret, ", default=");
     rb_str_append(ret, str);
+#ifdef HAVE_TAINT
     OBJ_INFECT(ret, str);
+#endif
 
     str = rb_inspect((VALUE)CONTEXT(self));
     rb_str_cat2(ret, ", cmp_proc=");
     rb_str_append(ret, str);
+#ifdef HAVE_TAINT
     OBJ_INFECT(ret, str);
+#endif
 
     rb_str_cat2(ret, ">");
+#ifdef HAVE_TAINT
     OBJ_INFECT(ret, self);
+#endif
     return ret;
 }
 

--- a/rbtree.c
+++ b/rbtree.c
@@ -2,9 +2,17 @@
  * MIT License
  * Copyright (c) 2002-2004, 2007, 2009 OZAWA Takuma
  */
-#include <ruby/ruby.h>
+#include <ruby.h>
+#ifdef HAVE_RUBY_VERSION_H
 #include <ruby/version.h>
+#else
+#include <version.h>
+#endif
+#ifdef HAVE_RUBY_ST_H
 #include <ruby/st.h>
+#else
+#include <st.h>
+#endif
 #include <stdarg.h>
 #include "dict.h"
 
@@ -17,6 +25,11 @@
 
 #ifndef RHASH_SET_IFNONE
 #define RHASH_SET_IFNONE(h, ifnone) (RHASH_IFNONE(h) = ifnone)
+#endif
+
+#ifndef RB_BLOCK_CALL_FUNC_ARGLIST
+#define RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg) \
+    VALUE yielded_arg, VALUE callback_arg
 #endif
 
 #if !defined(RUBY_API_VERSION_CODE) || (RUBY_API_VERSION_CODE < 20700)
@@ -37,10 +50,10 @@ typedef struct {
     int iter_lev;
 } rbtree_t;
 
-#define RBTREE(rbtree) DATA_PTR(rbtree)
-#define DICT(rbtree) ((rbtree_t*)RBTREE(rbtree))->dict
-#define IFNONE(rbtree) ((rbtree_t*)RBTREE(rbtree))->ifnone
-#define ITER_LEV(rbtree) ((rbtree_t*)RBTREE(rbtree))->iter_lev
+#define RBTREE(rbtree) ((rbtree_t*)DATA_PTR(rbtree))
+#define DICT(rbtree) RBTREE(rbtree)->dict
+#define IFNONE(rbtree) RBTREE(rbtree)->ifnone
+#define ITER_LEV(rbtree) RBTREE(rbtree)->iter_lev
 #define COMPARE(rbtree) DICT(rbtree)->dict_compare
 #define CONTEXT(rbtree) DICT(rbtree)->dict_context
 
@@ -98,6 +111,7 @@ rbtree_free_node(dnode_t* node, void* context)
     xfree(node);
 }
 
+NORETURN(static void rbtree_argc_error());
 static void
 rbtree_argc_error()
 {
@@ -139,9 +153,9 @@ static VALUE
 rbtree_alloc(VALUE klass)
 {
     dict_t* dict;
-    VALUE rbtree = Data_Wrap_Struct(klass, rbtree_mark, rbtree_free, 0);
-    RBTREE(rbtree) = ALLOC(rbtree_t);
-    MEMZERO(RBTREE(rbtree), rbtree_t, 1);
+    rbtree_t* rbtree_ptr;
+    VALUE rbtree = Data_Make_Struct(klass, rbtree_t, rbtree_mark, rbtree_free,
+                                    rbtree_ptr);
 
     dict = dict_create(rbtree_cmp);
     dict_set_allocator(dict, rbtree_alloc_node, rbtree_free_node,
@@ -149,8 +163,8 @@ rbtree_alloc(VALUE klass)
     if (klass == MultiRBTree)
         dict_allow_dupes(dict);
 
-    DICT(rbtree) = dict;
-    IFNONE(rbtree) = Qnil;
+    rbtree_ptr->dict = dict;
+    rbtree_ptr->ifnone = Qnil;
     return rbtree;
 }
 
@@ -266,8 +280,9 @@ typedef struct {
 } insert_node_t;
 
 static VALUE
-insert_node_body(insert_node_t* arg)
+insert_node_body(VALUE arg_)
 {
+    insert_node_t* arg = (insert_node_t*)arg_;
     if (dict_insert(arg->dict, arg->node, arg->key))
         arg->ret = NODE_NOT_FOUND;
     else
@@ -276,8 +291,9 @@ insert_node_body(insert_node_t* arg)
 }
 
 static VALUE
-insert_node_ensure(insert_node_t* arg)
+insert_node_ensure(VALUE arg_)
 {
+    insert_node_t* arg = (insert_node_t*)arg_;
     dict_t* dict = arg->dict;
     dnode_t* node = arg->node;
     switch (arg->ret) {
@@ -478,8 +494,9 @@ rbtree_each_ensure(VALUE self)
 }
 
 static VALUE
-rbtree_each_body(rbtree_each_arg_t* arg)
+rbtree_each_body(VALUE arg_)
 {
+    rbtree_each_arg_t* arg = (rbtree_each_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* node;
@@ -780,8 +797,9 @@ typedef struct {
 } rbtree_delete_if_arg_t;
 
 static VALUE
-rbtree_delete_if_ensure(rbtree_delete_if_arg_t* arg)
+rbtree_delete_if_ensure(VALUE arg_)
 {
+    rbtree_delete_if_arg_t* arg = (rbtree_delete_if_arg_t*)arg_;
     dict_t* dict = DICT(arg->self);
     dnode_list_t* list = arg->list;
 
@@ -798,8 +816,9 @@ rbtree_delete_if_ensure(rbtree_delete_if_arg_t* arg)
 }
 
 static VALUE
-rbtree_delete_if_body(rbtree_delete_if_arg_t* arg)
+rbtree_delete_if_body(VALUE arg_)
 {
+    rbtree_delete_if_arg_t* arg = (rbtree_delete_if_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* node;
@@ -1277,8 +1296,9 @@ typedef struct {
 } rbtree_bound_arg_t;
 
 static VALUE
-rbtree_bound_body(rbtree_bound_arg_t* arg)
+rbtree_bound_body(VALUE arg_)
 {
+    rbtree_bound_arg_t* arg = (rbtree_bound_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* lower_node = arg->lower_node;
@@ -1477,8 +1497,9 @@ pp_object_group(VALUE arg_)
 }
 
 static VALUE
-pp_block(VALUE nil, pp_arg_t* arg)
+pp_block(RB_BLOCK_CALL_FUNC_ARGLIST(nil, arg_))
 {
+    pp_arg_t* arg = (pp_arg_t*)arg_;
     VALUE pp = arg->pp;
     VALUE rbtree = arg->rbtree;
 
@@ -1489,7 +1510,7 @@ pp_block(VALUE nil, pp_arg_t* arg)
     rb_funcall(pp, id_pp, 1, IFNONE(rbtree));
     rb_funcall(pp, id_comma_breakable, 0);
     rb_funcall(pp, id_text, 1, rb_str_new2("cmp_proc="));
-    rb_funcall(pp, id_pp, 1, CONTEXT(rbtree));
+    rb_funcall(pp, id_pp, 1, (VALUE)CONTEXT(rbtree));
     return pp;
 }
 

--- a/test.rb
+++ b/test.rb
@@ -517,7 +517,9 @@ class RBTreeTest < Test::Unit::TestCase
   def test_to_hash
     @rbtree.default = "e"
     hash = @rbtree.to_hash
-    assert_equal(@rbtree.to_a.flatten, hash.to_a.flatten)
+    hash_a = hash.to_a
+    hash_a.sort! if RUBY_VERSION < "1.9"  # Hash ordering isn't stable in < 1.9.
+    assert_equal(@rbtree.to_a.flatten, hash_a.flatten)
     assert_equal("e", hash.default)
 
     rbtree = RBTree.new { "e" }

--- a/test.rb
+++ b/test.rb
@@ -534,7 +534,11 @@ class RBTreeTest < Test::Unit::TestCase
     tree, default, cmp_proc = match.to_a[1..-1]
     assert_equal(%({"a"=>"A", "b"=>"B", "c"=>"C", "d"=>"D"}), tree)
     assert_equal(%("e"), default)
-    assert_match(/#<Proc:\w+(@#{__FILE__}:\d+)?>/o, cmp_proc)
+    if @rbtree.cmp_proc.respond_to?("source_location")
+      assert_equal(File.basename(__FILE__), @rbtree.cmp_proc.source_location[0])
+    else
+      assert_match(/#<Proc:\w+(@#{__FILE__}:\d+)?>/o, cmp_proc)
+    end
 
     rbtree = RBTree.new
     assert_match(re, rbtree.inspect)

--- a/test.rb
+++ b/test.rb
@@ -518,6 +518,15 @@ class RBTreeTest < Test::Unit::TestCase
     @rbtree.default = "e"
     hash = @rbtree.to_hash
     assert_equal(@rbtree.to_a.flatten, hash.to_a.flatten)
+    assert_equal("e", hash.default)
+
+    rbtree = RBTree.new { "e" }
+    hash = rbtree.to_hash
+    if (hash.respond_to?(:default_proc))
+      assert_equal(rbtree.default_proc, hash.default_proc)
+    else
+      assert_equal(rbtree.default_proc, hash.default)
+    end
   end
 
   def test_to_rbtree


### PR DESCRIPTION
The Ruby core team decided to deprecate the taint mechanism in Ruby 2.7
and will remove that in Ruby 3.

https://bugs.ruby-lang.org/issues/16131
ruby/ruby#2476

In Ruby 2.7, `Object#{taint,untaint,trust,untrust}` and related
functions in the C-API no longer have an effect (all objects are always
considered untainted), and are now warned with deprecation messages.

The format of Proc inspect has changed too. Adjusted the affected test.

[Fixes #6]