### PR TITLE
rbtree.c: delete rb_gc_force_recycle as it's deprecated in Ruby 3.1

### DIFF
--- a/rbtree.c
+++ b/rbtree.c
@@ -665,8 +665,6 @@ copy_dict(VALUE src, VALUE dest, dict_comp_t cmp,  void* context)
         DICT(temp) = DICT(dest);
         DICT(dest) = t;
     }
-    rbtree_free(RBTREE(temp));
-    rb_gc_force_recycle(temp);
 }
 
 /*
@@ -1575,7 +1573,6 @@ rbtree_dump(VALUE self, VALUE _limit)
 
     ret = rb_marshal_dump(ary, Qnil);
     rb_ary_clear(ary);
-    rb_gc_force_recycle(ary);
     return ret;
 }
 
@@ -1596,7 +1593,6 @@ rbtree_s_load(VALUE klass, VALUE str)
     IFNONE(rbtree) = ptr[len];
 
     rb_ary_clear(ary);
-    rb_gc_force_recycle(ary);
     return rbtree;
 }
 


### PR DESCRIPTION
Related Ruby change: https://github.com/ruby/ruby/pull/4363/files
Explanation: https://blog.peterzhu.ca/rb_gc_force_recycle-deprecation/

Summary:

* Can leak resources
* Violates GC assumptions
* Double free issue

> rb_gc_force_recycle tells the garbage collector to forcibly reclaim the
> object. This was designed as an optimization for letting the garbage collector
> know which objects you know are dead and so the garbage collector can reclaim
> the memory (similar to how the free C library function works). This can reduce
> the number of garbage collections which can make Ruby run faster since garbage
> collection cycles are relatively costly in performance.

> It’s important to note that rb_gc_force_recycle reclaims the RVALUE of the
> object, with no regard to the type of the object or the contents of the
> object. This is unlike objects freed during regular garbage collection cycles
> since rb_gc_force_recycle does not free any resources (e.g. allocated memory,
> open file descriptors) held on by the object. This means that if the caller of
> rb_gc_force_recycle forgets to free the resources held by the object, then
> they will leak.

Also fixes a segfault when `GC.stress = true`.