### PR TITLE
rbtree.c: inherit from `rb_cObject` instead of `rb_cData`

### DIFF
--- a/rbtree.c
+++ b/rbtree.c
@@ -1652,7 +1652,7 @@ rbtree_s_load(VALUE klass, VALUE str)
  */
 void Init_rbtree()
 {
-    MultiRBTree = rb_define_class("MultiRBTree", rb_cData);
+    MultiRBTree = rb_define_class("MultiRBTree", rb_cObject);
     RBTree = rb_define_class("RBTree", MultiRBTree);
 
     rb_include_module(MultiRBTree, rb_mEnumerable);


### PR DESCRIPTION
`rb_cData` was deprecated and later on removed from Ruby 3.2+ (the release of
which hasn't happened as of time of writing).

Related commits:

* https://github.com/ruby/ruby/pull/3961/files
* https://github.com/ruby/ruby/pull/4208
* https://github.com/ruby/ruby/commit/7fbad9224188905a6d96dee5aad5b1e1564e4461

Reason for removal: https://bugs.ruby-lang.org/issues/3072

> [...] the Data class is an internal abstraction, not intended to be exposed to
> userland like this.