### PR TITLE
Fixes for: #16 Error installing on M1, Ruby 3.x

### DIFF
--- a/rbtree.c
+++ b/rbtree.c
@@ -121,11 +121,11 @@ rbtree_argc_error()
 static int
 rbtree_cmp(const void* key1, const void* key2, void* context)
 {
-  VALUE ret;
-  if (TYPE((VALUE)key1) == T_STRING && TYPE((VALUE)key2) == T_STRING)
-    return rb_str_cmp((VALUE)key1, (VALUE)key2);
-  ret = rb_funcall((VALUE)key1, id_cmp, 1, (VALUE)key2);
-  return cmpint(ret, (VALUE)key1, (VALUE)key2);
+    VALUE ret;
+    if (TYPE((VALUE)key1) == T_STRING && TYPE((VALUE)key2) == T_STRING)
+        return rb_str_cmp((VALUE)key1, (VALUE)key2);
+    ret = rb_funcall((VALUE)key1, id_cmp, 1, (VALUE)key2);
+    return cmpint(ret, (VALUE)key1, (VALUE)key2);
 }
 
 static int
@@ -377,7 +377,7 @@ rbtree_fetch(int argc, VALUE* argv, VALUE self)
         rbtree_argc_error();
     block_given = rb_block_given_p();
     if (block_given && argc == 2)
-  rb_warn("block supersedes default value argument");
+        rb_warn("block supersedes default value argument");
 
     node = dict_lookup(DICT(self), TO_KEY(argv[0]));
     if (node != NULL)

--- a/rbtree.c
+++ b/rbtree.c
@@ -121,11 +121,11 @@ rbtree_argc_error()
 static int
 rbtree_cmp(const void* key1, const void* key2, void* context)
 {
-    VALUE ret;
-    if (TYPE(key1) == T_STRING && TYPE(key2) == T_STRING)
-        return rb_str_cmp((VALUE)key1, (VALUE)key2);
-    ret = rb_funcall((VALUE)key1, id_cmp, 1, (VALUE)key2);
-    return cmpint(ret, (VALUE)key1, (VALUE)key2);
+  VALUE ret;
+  if (TYPE((VALUE)key1) == T_STRING && TYPE((VALUE)key2) == T_STRING)
+    return rb_str_cmp((VALUE)key1, (VALUE)key2);
+  ret = rb_funcall((VALUE)key1, id_cmp, 1, (VALUE)key2);
+  return cmpint(ret, (VALUE)key1, (VALUE)key2);
 }
 
 static int
@@ -301,7 +301,7 @@ insert_node_ensure(VALUE arg_)
         dict->dict_freenode(node, dict->dict_context);
         break;
     case NODE_NOT_FOUND:
-        if (TYPE(arg->key) == T_STRING)
+        if (TYPE((VALUE)arg->key) == T_STRING)
             node->dict_key = TO_KEY(rb_str_new4(GET_KEY(node)));
         break;
     case NODE_FOUND:
@@ -377,7 +377,7 @@ rbtree_fetch(int argc, VALUE* argv, VALUE self)
         rbtree_argc_error();
     block_given = rb_block_given_p();
     if (block_given && argc == 2)
-	rb_warn("block supersedes default value argument");
+  rb_warn("block supersedes default value argument");
 
     node = dict_lookup(DICT(self), TO_KEY(argv[0]));
     if (node != NULL)

--- a/rbtree3.gemspec
+++ b/rbtree3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rbtree3'
-  s.version = '0.7.0'
+  s.version = '0.7.1'
   s.authors = ['Kyrylo Silin', 'OZAWA Takuma']
   s.email = %w[silin@kyrylo.org]
 


### PR DESCRIPTION
For: https://github.com/kyrylo/rbtree3/issues/16

The change is to explicitly cast `key1` and `key2` as `VALUE` before calling the `TYPE` macro, as well as casting them as `VALUE` before passing them as arguments to `rb_str_cmp()` and `rb_funcall()`. This ensures that the correct `VALUE` type is used.

The `arg->key` argument is of type `const void*`, which is not compatible with `VALUE` (aka unsigned long) expected by the `TYPE` macro. To fix this error, `arg->key` needs to be casted to `VALUE` before passing it to `TYPE`.

Forked this to try and see if I can fix it. This is the build error that's happening on Apple M1 computers: `https://github.com/kyrylo/rbtree3/issues/16`

Locally, I was able to install this gem on my Apple M1 with Ruby 3.0.6 with these changes.

I'm not a C programmer, so please scrutinize.